### PR TITLE
feat: Add GitHub Actions CI/CD for Docker Hub deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy to Docker Hub
+
+on:
+  push:
+    branches:
+      - main # Triggers on push to the main branch
+
+jobs:
+  build_and_push_to_dockerhub:
+    name: Build and Push to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4 # Updated to v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4 # Updated to v4
+        with:
+          java-version: '17'
+          distribution: 'temurin' # Using Temurin, consistent with Dockerfile
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4 # Updated to v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build with Maven
+        run: ./mvnw clean install -B -DskipTests # -B for batch mode, -DskipTests to speed up CI build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3 # Updated to v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3 # Updated to v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5 # Updated to v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/validation-service # Assumes DOCKERHUB_USERNAME is your Docker Hub username and validation-service is the desired image name. Adjust if your repo name is different.
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5 # Updated to v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Stage 1: Build the application
+FROM eclipse-temurin:17-jdk-jammy as builder
+
+WORKDIR /workspace/app
+
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
+
+# Download dependencies
+RUN ./mvnw dependency:go-offline -B
+
+COPY src src
+
+# Build the application
+RUN ./mvnw package -DskipTests
+
+# Stage 2: Create the final lightweight image
+FROM eclipse-temurin:17-jre-jammy
+
+WORKDIR /app
+
+# Copy the JAR file from the builder stage
+COPY --from=builder /workspace/app/target/validation-service-*.jar app.jar
+
+EXPOSE 8080 # Or whatever port the application listens on, if any. Default for Spring Boot.
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,41 @@ Deploying to a development environment (or any other shared environment like sta
 
 This service is designed as a standard Spring Boot application, making it compatible with common Java deployment practices.
 
+## CI/CD with GitHub Actions
+
+This project is configured with a GitHub Actions workflow to automate the building and deployment of the application to Docker Hub.
+
+### Workflow Overview
+
+*   **Workflow File:** `.github/workflows/deploy.yml`
+*   **Trigger:** The workflow automatically runs on every `push` to the `main` branch.
+*   **Jobs:**
+    1.  **Build and Push to Docker Hub (`build_and_push_to_dockerhub`):**
+        *   Checks out the source code.
+        *   Sets up JDK 17.
+        *   Caches Maven dependencies for faster builds.
+        *   Builds the Spring Boot application using Maven (`mvn clean install -DskipTests`).
+        *   Sets up Docker Buildx.
+        *   Logs into Docker Hub using credentials stored in GitHub Secrets.
+        *   Extracts metadata for Docker image tagging (uses commit SHA and `latest`).
+        *   Builds the Docker image using the provided `Dockerfile`.
+        *   Pushes the built Docker image to Docker Hub. The image will be named `your-dockerhub-username/validation-service` (ensure your Docker Hub username is correctly configured in secrets and the image name in the workflow is as desired).
+
+### Required GitHub Secrets
+
+To enable the workflow to push to Docker Hub, you need to configure the following secrets in your GitHub repository settings (under "Settings" > "Secrets and variables" > "Actions"):
+
+*   `DOCKERHUB_USERNAME`: Your Docker Hub username.
+*   `DOCKERHUB_TOKEN`: Your Docker Hub access token. It is strongly recommended to use an access token with appropriate permissions rather than your Docker Hub password.
+
+### Docker Image Naming
+
+The pushed Docker image will be tagged with:
+*   The commit SHA (e.g., `your-dockerhub-username/validation-service:abcdef1234567890`)
+*   `latest` (for pushes to the `main` branch, e.g., `your-dockerhub-username/validation-service:latest`)
+
+Please replace `your-dockerhub-username/validation-service` in the workflow file (`.github/workflows/deploy.yml` in the `docker/metadata-action` step, under `images`) if you wish to use a different Docker Hub repository name or organization.
+
 ## Input / Output
 
 ### Input: Kafka Topic `instant.payment.inbound`


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the building and deployment of your application to Docker Hub.

Key changes:
-   **Added `Dockerfile`:** A multi-stage Dockerfile to build an optimized
    Docker image for your Spring Boot application.
-   **Added GitHub Actions Workflow (`.github/workflows/deploy.yml`):**
    -   Triggers on push to the `main` branch.
    -   Builds your Java application using Maven.
    -   Builds a Docker image using the new `Dockerfile`.
    -   Pushes the Docker image to Docker Hub.
    -   Uses GitHub Secrets for Docker Hub credentials (`DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`).
    -   Tags images with the commit SHA and `latest`.
-   **Updated `README.md`:**
    -   Added a new section "CI/CD with GitHub Actions" explaining the
        workflow, required secrets for Docker Hub, and Docker image naming.

This setup enables continuous integration and deployment of your application as a Docker container to Docker Hub.